### PR TITLE
Exercise 2, main branch (2025.04.21.)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ build
 
 # Athena artifact(s).
 eventLoopHeartBeat.txt
+hostnamelookup.tmp
+PoolFileCatalog.xml

--- a/02_CUDA_xAODCalib.ipynb
+++ b/02_CUDA_xAODCalib.ipynb
@@ -1,0 +1,174 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c7fe1e52",
+   "metadata": {},
+   "source": [
+    "# Calibrate Electrons on a GPU With CUDA\n",
+    "\n",
+    "The second exercise shows some good practices for how one can offload complex\n",
+    "data structures to a GPU in an optimal way.\n",
+    "\n",
+    "## Build the Project\n",
+    "\n",
+    "Building the project works exactly the same as in the first exercise. If you\n",
+    "already went through that, your [scripts/build_env.sh](scripts/build_env.sh)\n",
+    "should already be set up correctly, so you should be able to execute:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "618e82e6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!./scripts/run_command.sh cmake -DCMAKE_BUILD_TYPE=Debug -S . -B build\n",
+    "!./scripts/run_command.sh cmake --build build"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "db155953",
+   "metadata": {},
+   "source": [
+    "## Code Structure\n",
+    "\n",
+    "The code is set up slightly more realistically in this second example.\n",
+    "  - The algorithm's C\\+\\+ code is not exposed to the CUDA compiler, but rather\n",
+    "    kept in pure C\\+\\+ source files.\n",
+    "    ([ElectronCalibCUDAAlg.h](CUDAExamples/src/02_xAODCalib/ElectronCalibCUDAAlg.h),\n",
+    "    [ElectronCalibCUDAAlg.cxx](CUDAExamples/src/02_xAODCalib/ElectronCalibCUDAAlg.cxx))\n",
+    "    While at the time of writing we use the C\\+\\+20 standard both when building\n",
+    "    C\\+\\+ and CUDA code, the two may not always use the same standard. So it is\n",
+    "    good practice to limit the amount of Athena code that the `nvcc` compiler\n",
+    "    would be exposed to.\n",
+    "  - The device code is compiled using a \"standalone\" C\\+\\+ function.\n",
+    "    ([calibrateElectrons.h](CUDAExamples/src/02_xAODCalib/calibrateElectrons.h),\n",
+    "    [calibrateElectrons.cu](CUDAExamples/src/02_xAODCalib/calibrateElectrons.cu))\n",
+    "    It is set up to make use of `\"GaudiKernel/StatusCode.h\"`, but it could\n",
+    "    communicate errors back to the algorithm in a simpler way as well.\n",
+    "  - To represent the data coming from\n",
+    "    [xAOD::Electron](https://atlas-sw-doxygen.web.cern.ch/atlas-sw-doxygen/atlas_main--Doxygen/docs/html/d3/da7/classxAOD_1_1Electron__v1.html)\n",
+    "    objects, the example makes use of the\n",
+    "    [SoA helper code](https://acts-project.github.io/vecmem/namespacevecmem_1_1edm.html)\n",
+    "    of [VecMem](https://acts-project.github.io/vecmem/).\n",
+    "    [ElectronDeviceContainer.h](CUDAExamples/src/02_xAODCalib/ElectronDeviceContainer.h)\n",
+    "    Along with some of the memory management features provided by that library.\n",
+    "\n",
+    "## Example Job\n",
+    "\n",
+    "The same as the first exercise, this one also comes with a CA configuration\n",
+    "that you can try with:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ac3df6ba",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!./scripts/run_command.sh ./build/CMakeFiles/atlas_build_run.sh athena.py --CA CUDAExamples/02_xAODCalibConfig.py"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f0a01371",
+   "metadata": {},
+   "source": [
+    "Much like the first example, this one is broken out of the box as well.\n",
+    "\n",
+    "## Tasks\n",
+    "\n",
+    "### 1. Make The Job Work\n",
+    "\n",
+    "The example job should be stopping a couple of events into execution, with:\n",
+    "\n",
+    "```text\n",
+    "...\n",
+    "AthenaEventLoopMgr                                   INFO   ===>>>  done processing event #2201575275, run #431906 5 events processed so far  <<<===\n",
+    "AthenaEventLoopMgr                                   INFO   ===>>>  start processing event #2201577975, run #431906 5 events processed so far  <<<===\n",
+    "GPUTutorial::ElectronCalibCUDAAlg                   FATAL Standard std::exception is caught in sysExecute\n",
+    "GPUTutorial::ElectronCalibCUDAAlg                   ERROR SG::ExcBadAuxVar: Attempt to retrieve nonexistent aux data item `::eta' (212).\n",
+    "GPUTutorial::ElectronCalibCUDAAlg                   ERROR Maximum number of errors ( 'ErrorMax':1) reached.\n",
+    "AthAlgSeq                                            INFO execute of [GPUTutorial::ElectronCalibCUDAAlg] did NOT succeed\n",
+    "AthAlgSeq                                           ERROR Maximum number of errors ( 'ErrorMax':1) reached.\n",
+    "...\n",
+    "```\n",
+    "\n",
+    "The reason for this failure is something that is a very typical mistake when\n",
+    "writing GPU code. Even if the manifestation of the error is not quite the same\n",
+    "as how it would usually show up.\n",
+    "\n",
+    "Run the job in a debugger to find the reason for the surprising exception.\n",
+    "Specifically keep an eye on container sizes event by event to see what's\n",
+    "different about the problematic one. As a hint, it's best to first set up\n",
+    "a breakpoint on `GPUTutorial::ElectronCalibCUDAAlg::execute`, and when the\n",
+    "program first stops, set up a catchpoint on all thrown exceptions. (During the\n",
+    "initialization of the job a number of exceptions are thrown. Which are best\n",
+    "avoided like this.)\n",
+    "\n",
+    "### 2. Make The Job Thread Safe\n",
+    "\n",
+    "Once you worked around the issue causing the previous failure, the code is\n",
+    "technically not thread safe. Though it may be hard to test this during the\n",
+    "tutorial. Still, try to run with many parallel CPU threads, and see if you can\n",
+    "make the code crash. (You may not be able to...)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a0c8ddde",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!./scripts/run_command.sh ./build/CMakeFiles/atlas_build_run.sh athena.py --threads=10 --CA CUDAExamples/02_xAODCalibConfig.py"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "72aa9c79",
+   "metadata": {},
+   "source": [
+    "Since this may or may not present itself, check which memory resources get used\n",
+    "in the example algorithm. And remove the use of any thread-unsafe objects, if\n",
+    "you find any being used.\n",
+    "\n",
+    "### 3. Make The Job Do Something Useful\n",
+    "\n",
+    "The meat of the exercise is to try to do something useful inside of\n",
+    "`GPUTutorial::Kernels::calibrateElectrons`. Update the code to:\n",
+    "  - Send additional electron variables to the GPU beside \"eta\" and \"phi\";\n",
+    "  - Have the kernel perform some modification on the electron momentum, using\n",
+    "    the properties of the electron. Mimicking a sort of calibration.\n",
+    "  - Try to write a helper function that would be used by the kernel for this\n",
+    "    \"calibration\". See how you need to define/implement that helper function to\n",
+    "    make it usable from both host and device code."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/CUDAExamples/CMakeLists.txt
+++ b/CUDAExamples/CMakeLists.txt
@@ -12,10 +12,15 @@ if(NOT CMAKE_CUDA_COMPILER)
 endif()
 enable_language(CUDA)
 
+# Find the required packages.
+find_package(vecmem COMPONENTS CUDA)
+
 # Component(s) in the package.
 atlas_add_component(CUDAExamples
    src/*/*.h src/*/*.cxx src/*/*.cu
-   LINK_LIBRARIES AthenaBaseComps )
+   LINK_LIBRARIES vecmem::core vecmem::cuda
+                  GaudiKernel AthenaBaseComps AthContainers StoreGateLib
+                  xAODEgamma)
 
 # Install files from the package.
 atlas_install_python_modules(python/*.py)

--- a/CUDAExamples/python/02_xAODCalibConfig.py
+++ b/CUDAExamples/python/02_xAODCalibConfig.py
@@ -8,16 +8,20 @@ from AthenaConfiguration.AllConfigFlags import initConfigFlags
 from AthenaConfiguration.ComponentAccumulator import ComponentAccumulator
 from AthenaConfiguration.ComponentFactory import CompFactory
 from AthenaConfiguration.MainServicesConfig import MainServicesCfg
+from AthenaConfiguration.TestDefaults import defaultTestFiles
+
+# I/O import(s).
+from AthenaPoolCnvSvc.PoolReadConfig import PoolReadCfg
 
 # System import(s).
 import sys
 
 
-def LinearTransformCUDAAlgCfg(flags, **kwargs):
+def ElectronCalibCUDAAlgCfg(flags, **kwargs):
     # Create an accumulator to hold the configuration.
     result = ComponentAccumulator()
     # Create the example algorithm.
-    alg = CompFactory.GPUTutorial.LinearTransformCUDAAlg(**kwargs)
+    alg = CompFactory.GPUTutorial.ElectronCalibCUDAAlg(**kwargs)
     result.addEventAlgo(alg)
     # Return the result to the caller.
     return result
@@ -27,15 +31,19 @@ if __name__ == '__main__':
 
     # Set up the job's flags.
     flags = initConfigFlags()
-    flags.Exec.MaxEvents = 100
+    flags.Exec.MaxEvents = 1000
+    flags.Input.Files = defaultTestFiles.AOD_RUN3_DATA
     flags.fillFromArgs()
     flags.lock()
 
     # Set up the main services.
     acc = MainServicesCfg(flags)
 
+    # Set up the input file reading.
+    acc.merge(PoolReadCfg(flags))
+
     # Set up the tutorial algorithm.
-    acc.merge(LinearTransformCUDAAlgCfg(flags))
+    acc.merge(ElectronCalibCUDAAlgCfg(flags))
 
     # Run the configuration.
     sys.exit(acc.run().isFailure())

--- a/CUDAExamples/src/01_LinearTransform/LinearTransformCUDAAlg.h
+++ b/CUDAExamples/src/01_LinearTransform/LinearTransformCUDAAlg.h
@@ -18,9 +18,9 @@ namespace GPUTutorial
       /// @{
 
       /// Function initializing the algorithm
-      virtual StatusCode initialize() override;
+      StatusCode initialize() override;
       /// Function executing the algorithm
-      virtual StatusCode execute(const EventContext &ctx) const override;
+      StatusCode execute(const EventContext &ctx) const override;
 
       /// @}
 

--- a/CUDAExamples/src/02_xAODCalib/ElectronCalibCUDAAlg.cxx
+++ b/CUDAExamples/src/02_xAODCalib/ElectronCalibCUDAAlg.cxx
@@ -1,0 +1,122 @@
+// Copyright (C) 2002-2025 CERN for the benefit of the ATLAS collaboration
+
+// Local include(s).
+#include "ElectronCalibCUDAAlg.h"
+#include "ElectronDeviceContainer.h"
+#include "calibrateElectrons.h"
+
+// Framework include(s).
+#include "AthContainers/tools/copyAuxStoreThinned.h"
+#include "StoreGate/ReadHandle.h"
+#include "StoreGate/WriteHandle.h"
+#include "xAODCore/AuxContainerBase.h"
+
+// VecMem include(s).
+#include <vecmem/memory/cuda/host_memory_resource.hpp>
+#include <vecmem/memory/cuda/device_memory_resource.hpp>
+#include <vecmem/memory/pool_memory_resource.hpp>
+#include <vecmem/memory/synchronized_memory_resource.hpp>
+#include <vecmem/utils/cuda/copy.hpp>
+
+namespace GPUTutorial
+{
+
+   struct ElectronCalibCUDAAlg::MemoryResources
+   {
+      /// Uncached host memory resource
+      vecmem::cuda::host_memory_resource m_hostMR;
+      /// Cached host memory resource
+      vecmem::pool_memory_resource m_cachedHostMR{m_hostMR};
+      /// Synchronized and cached host memory resource
+      vecmem::synchronized_memory_resource m_syncHostMR{m_cachedHostMR};
+
+      /// Uncached device memory resource
+      vecmem::cuda::device_memory_resource m_deviceMR;
+      /// Cached device memory resource
+      vecmem::pool_memory_resource m_cachedDeviceMR{m_deviceMR};
+      /// Synchronized and cached device memory resource
+      vecmem::synchronized_memory_resource m_syncDeviceMR{m_cachedDeviceMR};
+   };
+
+   ElectronCalibCUDAAlg::ElectronCalibCUDAAlg(const std::string &name,
+                                              ISvcLocator *svcloc)
+       : AthReentrantAlgorithm(name, svcloc) {}
+
+   ElectronCalibCUDAAlg::~ElectronCalibCUDAAlg() = default;
+
+   StatusCode ElectronCalibCUDAAlg::initialize()
+   {
+      // Set up the memory resources.
+      m_memoryResources = std::make_unique<MemoryResources>();
+
+      // Set up the input and output keys.
+      ATH_CHECK(m_inputKey.initialize());
+      ATH_CHECK(m_outputKey.initialize());
+
+      // Return gracefuilly.
+      return StatusCode::SUCCESS;
+   }
+
+   StatusCode ElectronCalibCUDAAlg::execute(const EventContext &ctx) const
+   {
+      // Get the input container.
+      SG::ReadHandle input(m_inputKey, ctx);
+
+      // Set up a host buffer for the electron container.
+      auto nElectrons = static_cast<ElectronDeviceContainer::buffer::size_type>(
+          input->size());
+      ElectronDeviceContainer::buffer
+          hostBuffer{nElectrons, m_memoryResources->m_syncHostMR};
+
+      // Copy data from the xAOD container into the host buffer.
+      static const SG::AuxElement::ConstAccessor<float> etaAcc("eta");
+      static const SG::AuxElement::ConstAccessor<float> phiAcc("phi");
+      std::memcpy(hostBuffer.get<0>().ptr(), etaAcc.getDataArray(*input),
+                  nElectrons * sizeof(float));
+      std::memcpy(hostBuffer.get<1>().ptr(), phiAcc.getDataArray(*input),
+                  nElectrons * sizeof(float));
+
+      // Helper object used to copy data between the host and the device.
+      vecmem::cuda::copy copy;
+
+      // Create two device buffers.
+      ElectronDeviceContainer::buffer deviceInputBuffer{
+          nElectrons, m_memoryResources->m_cachedDeviceMR};
+      copy.setup(deviceInputBuffer)->wait();
+      ElectronDeviceContainer::buffer deviceOutputBuffer{
+          nElectrons, m_memoryResources->m_cachedDeviceMR};
+      copy.setup(deviceOutputBuffer)->wait();
+
+      // Copy data into the input buffer.
+      copy(hostBuffer, deviceInputBuffer)->wait();
+
+      // Run the GPU calibration in a separate function.
+      ATH_CHECK(calibrateElectrons(deviceInputBuffer, deviceOutputBuffer));
+
+      // Copy the output buffer back to the host.
+      copy(deviceOutputBuffer, hostBuffer)->wait();
+
+      // Construct the output container.
+      auto outputAux = std::make_unique<xAOD::AuxContainerBase>();
+      SG::copyAuxStoreThinned(*(input->getConstStore()), *outputAux, nullptr);
+      std::memcpy(outputAux->getData(etaAcc.auxid(), nElectrons, nElectrons),
+                  hostBuffer.get<0>().ptr(), nElectrons * sizeof(float));
+      std::memcpy(outputAux->getData(phiAcc.auxid(), nElectrons, nElectrons),
+                  hostBuffer.get<1>().ptr(), nElectrons * sizeof(float));
+      auto outputInterface = std::make_unique<xAOD::ElectronContainer>();
+      for (std::size_t i = 0; i < nElectrons; ++i)
+      {
+         outputInterface->push_back(new xAOD::Electron());
+      }
+      outputInterface->setStore(outputAux.get());
+
+      // Record the output container(s).
+      SG::WriteHandle output(m_outputKey, ctx);
+      ATH_CHECK(output.record(std::move(outputInterface),
+                              std::move(outputAux)));
+
+      // Return gracefuilly.
+      return StatusCode::SUCCESS;
+   }
+
+} // namespace GPUTutorial

--- a/CUDAExamples/src/02_xAODCalib/ElectronCalibCUDAAlg.h
+++ b/CUDAExamples/src/02_xAODCalib/ElectronCalibCUDAAlg.h
@@ -1,0 +1,64 @@
+// Copyright (C) 2002-2025 CERN for the benefit of the ATLAS collaboration
+#ifndef CUDAEXAMPLES_ELECTRONCALIBCUDAALG_H
+#define CUDAEXAMPLES_ELECTRONCALIBCUDAALG_H
+
+// Framework include(s).
+#include "AthenaBaseComps/AthReentrantAlgorithm.h"
+#include "StoreGate/ReadHandleKey.h"
+#include "StoreGate/WriteHandleKey.h"
+#include "xAODEgamma/ElectronContainer.h"
+
+// System include(s).
+#include <memory>
+
+namespace GPUTutorial
+{
+   /// Example algorithm performing a calibration on xAOD::Electron objects
+   class ElectronCalibCUDAAlg final : public AthReentrantAlgorithm
+   {
+   public:
+      /// Constructor
+      ElectronCalibCUDAAlg(const std::string &name, ISvcLocator *svcloc);
+      /// Destructor
+      ~ElectronCalibCUDAAlg() override;
+
+      /// @name Functions inherited from @c AthReentrantAlgorithm
+      /// @{
+
+      /// Function initializing the algorithm
+      StatusCode initialize() override;
+      /// Function executing the algorithm
+      StatusCode execute(const EventContext &ctx) const override;
+
+      /// @}
+
+   private:
+      /// @name Algorithm properties
+      /// @{
+
+      /// The input container key
+      SG::ReadHandleKey<xAOD::ElectronContainer> m_inputKey{
+          this, "InputContainer", "Electrons",
+          "The input electron container"};
+      /// The output container key
+      SG::WriteHandleKey<xAOD::ElectronContainer> m_outputKey{
+          this, "OutputContainer", "CalibratedElectrons",
+          "The output electron container"};
+
+      /// @}
+
+      /// @name Algorithm data members
+      /// @{
+
+      /// PIMPL structure of memory resources
+      struct MemoryResources;
+      /// Memory resources used by the algorithm
+      std::unique_ptr<MemoryResources> m_memoryResources;
+
+      /// @}
+
+   }; // class ElectronCalibCUDAAlg
+
+} // namespace GPUTutorial
+
+#endif // CUDAEXAMPLES_ELECTRONCALIBCUDAALG_H

--- a/CUDAExamples/src/02_xAODCalib/ElectronDeviceContainer.h
+++ b/CUDAExamples/src/02_xAODCalib/ElectronDeviceContainer.h
@@ -1,0 +1,43 @@
+// Copyright (C) 2002-2025 CERN for the benefit of the ATLAS collaboration
+#ifndef CUDAEXAMPLES_ELECTRONDEVICECONTAINER_H
+#define CUDAEXAMPLES_ELECTRONDEVICECONTAINER_H
+
+// VecMem include(s).
+#include <vecmem/edm/container.hpp>
+
+namespace GPUTutorial
+{
+   /// Interface for the VecMem based GPU friendly ElectronDeviceContainer.
+   template <typename BASE>
+   struct ElectronDeviceInterface : public BASE
+   {
+      /// Inherit the base class's constructor(s)
+      using BASE::BASE;
+
+      /// Inherit the base class's assignment operator(s)
+      using BASE::operator=;
+
+      /// Get the pseudorapidity of the electrons (const)
+      VECMEM_HOST_AND_DEVICE
+      const auto &eta() const { return BASE::template get<0>(); }
+      /// Get the pseudorapidity of the electrons (non-const)
+      VECMEM_HOST_AND_DEVICE
+      auto &eta() { return BASE::template get<0>(); }
+
+      /// Get the azimuthal angles of the electrons (const)
+      VECMEM_HOST_AND_DEVICE
+      const auto &phi() const { return BASE::template get<1>(); }
+      /// Get the azimuthal angles of the electrons (non-const)
+      VECMEM_HOST_AND_DEVICE
+      auto &phi() { return BASE::template get<1>(); }
+
+   }; // struct ElectronDeviceInterface
+
+   /// SoA, GPU friendly electron container.
+   using ElectronDeviceContainer = vecmem::edm::container<
+       ElectronDeviceInterface, vecmem::edm::type::vector<float>,
+       vecmem::edm::type::vector<float>>;
+
+} // namespace GPUTutorial
+
+#endif // CUDAEXAMPLES_ELECTRONDEVICECONTAINER_H

--- a/CUDAExamples/src/02_xAODCalib/calibrateElectrons.cu
+++ b/CUDAExamples/src/02_xAODCalib/calibrateElectrons.cu
@@ -1,0 +1,74 @@
+// Copyright (C) 2002-2025 CERN for the benefit of the ATLAS collaboration
+
+// Local include(s).
+#include "calibrateElectrons.h"
+
+// Framework include(s).
+#include "AthenaKernel/errorcheck.h"
+
+/// Helper macro for checking CUDA calls
+#define ATH_CUDA_CHECK(EXP)                                           \
+   do                                                                 \
+   {                                                                  \
+      const cudaError_t ce = EXP;                                     \
+      if (ce != cudaSuccess)                                          \
+      {                                                               \
+         REPORT_ERROR_WITH_CONTEXT(StatusCode::FAILURE,               \
+                                   "GPUTutorial::calibrateElectrons") \
+             << "Failed to execute \""                                \
+             << #EXP << "\" because:"                                 \
+             << cudaGetErrorString(ce);                               \
+         return StatusCode::FAILURE;                                  \
+      }                                                               \
+   } while (false)
+
+namespace GPUTutorial
+{
+   namespace Kernels
+   {
+      /// Simple kernel "calibrating" electrons
+      __global__ void
+      calibrateElectrons(ElectronDeviceContainer::const_view inputView,
+                         ElectronDeviceContainer::view outputView)
+      {
+         // Get the index of the current thread.
+         const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+         // Construct the device containers.
+         const ElectronDeviceContainer::const_device input(inputView);
+         ElectronDeviceContainer::device output(outputView);
+
+         // Check if the index is within bounds.
+         if (idx >= input.size())
+         {
+            return;
+         }
+
+         // Copy the input electron to the output container.
+         output[idx].eta() = input[idx].eta();
+         output[idx].phi() = input[idx].phi();
+
+         // Perform some calibration on the output electron.
+      }
+
+   } // namespace Kernels
+
+   StatusCode calibrateElectrons(ElectronDeviceContainer::const_view input,
+                                 ElectronDeviceContainer::view output)
+   {
+      // Launch the kernel.
+      const int blockSize = 256;
+      const int numBlocks = (input.capacity() + blockSize - 1) / blockSize;
+      Kernels::calibrateElectrons<<<numBlocks, blockSize>>>(input, output);
+
+      // Check for errors in kernel launch.
+      ATH_CUDA_CHECK(cudaGetLastError());
+
+      // Wait for the device to finish with the kernel.
+      ATH_CUDA_CHECK(cudaDeviceSynchronize());
+
+      // Return gracefully.
+      return StatusCode::SUCCESS;
+   }
+
+} // namespace GPUTutorial

--- a/CUDAExamples/src/02_xAODCalib/calibrateElectrons.h
+++ b/CUDAExamples/src/02_xAODCalib/calibrateElectrons.h
@@ -1,0 +1,20 @@
+// Copyright (C) 2002-2025 CERN for the benefit of the ATLAS collaboration
+#ifndef CUDAEXAMPLES_CALIBRATEELECTRONS_H
+#define CUDAEXAMPLES_CALIBRATEELECTRONS_H
+
+// Framework include(s).
+#include "GaudiKernel/StatusCode.h"
+
+// Local include(s).
+#include "ElectronDeviceContainer.h"
+
+namespace GPUTutorial
+{
+
+   /// Standalone function to calibrate the electrons
+   StatusCode calibrateElectrons(ElectronDeviceContainer::const_view input,
+                                 ElectronDeviceContainer::view output);
+
+} // namespace GPUTutorial
+
+#endif // CUDAEXAMPLES_CALIBRATEELECTRONS_H

--- a/CUDAExamples/src/components/CUDAExamples_entries.cxx
+++ b/CUDAExamples/src/components/CUDAExamples_entries.cxx
@@ -2,6 +2,8 @@
 
 // Local include(s).
 #include "../01_LinearTransform/LinearTransformCUDAAlg.h"
+#include "../02_xAODCalib/ElectronCalibCUDAAlg.h"
 
 // Declare the component(s).
 DECLARE_COMPONENT(GPUTutorial::LinearTransformCUDAAlg)
+DECLARE_COMPONENT(GPUTutorial::ElectronCalibCUDAAlg)

--- a/README.md
+++ b/README.md
@@ -29,3 +29,5 @@ The exercises are documented in individual Python notebooks. Please open these
 to follow the individual exercises.
   - [Exercise 1](01_CUDA_LinearTransform.ipynb): Set up a simple CUDA algorithm,
     debug why it's not working, and fix its memory leaks.
+  - [Exercise 2](02_CUDA_xAODCalib.ipynb): Work with a "more realistic" Athena
+    algorithm that takes data from, and returns data to an xAOD container.

--- a/scripts/build_env.sh
+++ b/scripts/build_env.sh
@@ -3,6 +3,10 @@
 # Script setting up the build environment for the tutorial.
 #
 
+# Clean out the environment as a first step.
+unset CMAKE_PREFIX_PATH
+unset ROOTSYS
+
 # Set up ALRB.
 export ATLAS_LOCAL_ROOT_BASE=/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase
 source $ATLAS_LOCAL_ROOT_BASE/user/atlasLocalSetup.sh
@@ -14,18 +18,17 @@ asetup Athena,25.0.29
 if [ ! -f "${CUDACXX}" ]; then
 
    # Directory to set up CUDA from.
-   CUDA_DIR="/your/path/to/cuda"
+   CUDA_HOME=${CUDA_HOME:-"/your/path/to/cuda"}
 
    # (Try to) Set up CUDA.
-   if [ ! -d "${CUDA_DIR}" ]; then
+   if [ ! -d "${CUDA_HOME}" ]; then
       echo "ERROR:"
       echo "ERROR: CUDA not available. Please configure the setup script!"
       echo "ERROR:"
-      exit 1
    else
-      export CMAKE_PREFIX_PATH="${CUDA_DIR}"${CMAKE_PREFIX_PATH:+:${CMAKE_PREFIX_PATH}}
-      export PATH="${CUDA_DIR}/bin"${PATH:+:${PATH}}
-      export LD_LIBRARY_PATH="${CUDA_DIR}/lib64"{LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+      export CMAKE_PREFIX_PATH="${CUDA_HOME}"${CMAKE_PREFIX_PATH:+:${CMAKE_PREFIX_PATH}}
+      export PATH="${CUDA_HOME}/bin"${PATH:+:${PATH}}
+      export LD_LIBRARY_PATH="${CUDA_HOME}/lib64"{LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
       export CUDACXX=`which nvcc`
    fi
 fi


### PR DESCRIPTION
The second exercise makes use of [vecmem](https://github.com/acts-project/vecmem) to demonstrate how to deal with more complex/realistic data management scenarios.

The main lessons being on:
  - what to do with empty containers;
  - watching out for the non-MT-friendliness of memory caching;
  - how to take data out of, and put it back into xAOD containers efficiently;
  - how to write functions that would be usable in both host and device code.

This PR in principle fixes #2. I tried to update `build_env.sh` to be more user friendly on Perlmutter. Even if it may make it a bit less friendly to people only using the notebooks.

Pinging @beojan, @cgleggett.