### PR TITLE
Perlmutter Compatibility, main branch (2025.04.22.)

### DIFF
--- a/01_CUDA_LinearTransform.ipynb
+++ b/01_CUDA_LinearTransform.ipynb
@@ -13,13 +13,33 @@
     "\n",
     "## Build The Project\n",
     "\n",
-    "As the very first step, let's try to build the project."
+    "As the very first step, let's try to build the project.\n",
+    "  - On Perlmutter:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "a910b735",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!./scripts/run_on_perlmutter.sh cmake -DCMAKE_BUILD_TYPE=Debug -S . -B build\n",
+    "!./scripts/run_on_perlmutter.sh cmake --build build"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c1420ac7-0eb0-42c8-bd8f-b45838d47963",
+   "metadata": {},
+   "source": [
+    "  - On SWAN:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dabad20e-1fea-4e12-8251-df00603863dd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -62,7 +82,8 @@
     "\n",
     "## Running The Code As Is\n",
     "\n",
-    "Try to execute the code in its present form!"
+    "Try to execute the code in its present form!\n",
+    "  - On Perlmutter:"
    ]
   },
   {
@@ -70,6 +91,26 @@
    "execution_count": null,
    "id": "258ff7e7",
    "metadata": {},
+   "outputs": [],
+   "source": [
+    "!./scripts/run_on_perlmutter.sh ./build/CMakeFiles/atlas_build_run.sh athena.py --threads=2 --CA CUDAExamples/01_LinearTransformConfig.py"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "27ff300e-99ee-4253-bbd2-b70dea303cc1",
+   "metadata": {},
+   "source": [
+    "  - On SWAN:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "42349778-e3bf-4165-a262-5715d6e37dc3",
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "!./scripts/run_command.sh ./build/CMakeFiles/atlas_build_run.sh athena.py --threads=2 --CA CUDAExamples/01_LinearTransformConfig.py"
@@ -97,13 +138,33 @@
     "make it a little easier to do everything from the notebook directly, the\n",
     "following command will run a batched debug job (with the help of\n",
     "[01_LinearTransformCrashBacktrace.txt](CUDAExamples/debug/01_LinearTransformCrashBacktrace.txt)),\n",
-    "printing the relevant output necessary to understand what it going wrong."
+    "printing the relevant output necessary to understand what it going wrong.\n",
+    "\n",
+    "  - On Perlmutter:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "ee309de2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!./scripts/run_on_perlmutter.sh ./build/CMakeFiles/atlas_build_run.sh ./scripts/cuda-gdb.sh --batch --command=./CUDAExamples/debug/01_LinearTransformCrashBacktrace.txt --args python ./CUDAExamples/python/01_LinearTransformConfig.py"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b8544587-c105-4a54-9abd-4ae822aa3943",
+   "metadata": {},
+   "source": [
+    "  - On SWAN:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "edb0525f-09b5-4592-b277-55a660a23c19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -117,13 +178,32 @@
    "source": [
     "Beside `cuda-gdb`, another very good tool to use to find problems in CUDA code,\n",
     "is [compute-sanitizer](https://docs.nvidia.com/compute-sanitizer/index.html).\n",
-    "Use the following command to inspect the example job:"
+    "Use the following command to inspect the example job.\n",
+    "  - On Perlmutter:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "2a5c6169",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!./scripts/run_on_perlmutter.sh ./build/CMakeFiles/atlas_build_run.sh compute-sanitizer --leak-check=full athena.py --CA CUDAExamples/01_LinearTransformConfig.py"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "21edbcd4-0b71-40b3-a0a8-be41b6e2b631",
+   "metadata": {},
+   "source": [
+    "  - On SWAN:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "970da1a1-fa52-407c-958e-fd3f385c6f7e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -144,13 +224,32 @@
     "  - Try to update the code such that memory would be freed even in case of\n",
     "    runtime errors.\n",
     "\n",
-    "After you updated the code, run the following cell to re-build it:"
+    "After you updated the code, run the following cell to re-build it.\n",
+    "  - On Perlmutter:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "44c4aa68",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!./scripts/run_on_perlmutter.sh cmake --build build"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "92aeb16f-7f00-4e68-aca5-13c40946a131",
+   "metadata": {},
+   "source": [
+    "  - On SWAN:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "765f8ca9-2fa2-4dda-8e0c-a7cd9d54c482",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -188,7 +287,8 @@
     "ApplicationMgr                                                    INFO Application Manager Terminated successfully\n",
     "```\n",
     "\n",
-    "Also check that `compute-sanitizer` would not report any memory leaks!"
+    "Also check that `compute-sanitizer` would not report any memory leaks!\n",
+    "  - On Perlmutter:"
    ]
   },
   {
@@ -198,13 +298,31 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "!./scripts/run_on_perlmutter.sh ./build/CMakeFiles/atlas_build_run.sh athena.py --threads=2 --CA CUDAExamples/01_LinearTransformConfig.py"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "130d8147-d950-45b4-8a57-da3216f9e11b",
+   "metadata": {},
+   "source": [
+    "  - On SWAN:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "affb4d95-d71f-4501-8590-486220bf2d61",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "!./scripts/run_command.sh ./build/CMakeFiles/atlas_build_run.sh athena.py --threads=2 --CA CUDAExamples/01_LinearTransformConfig.py"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "NERSC Python",
    "language": "python",
    "name": "python3"
   },
@@ -218,7 +336,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,

--- a/02_CUDA_xAODCalib.ipynb
+++ b/02_CUDA_xAODCalib.ipynb
@@ -14,13 +14,33 @@
     "\n",
     "Building the project works exactly the same as in the first exercise. If you\n",
     "already went through that, your [scripts/build_env.sh](scripts/build_env.sh)\n",
-    "should already be set up correctly, so you should be able to execute:"
+    "should already be set up correctly, so you should be able to execute.\n",
+    "  - On Perlmutter:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "618e82e6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!./scripts/run_on_perlmutter.sh cmake -DCMAKE_BUILD_TYPE=Debug -S . -B build\n",
+    "!./scripts/run_on_perlmutter.sh cmake --build build"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e3554638-16ac-4c3a-9950-d2a788acee12",
+   "metadata": {},
+   "source": [
+    "  - On SWAN:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "109c18ab-ae98-43c9-aee9-24097fcf4467",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -60,13 +80,32 @@
     "## Example Job\n",
     "\n",
     "The same as the first exercise, this one also comes with a CA configuration\n",
-    "that you can try with:"
+    "that you can try with:\n",
+    "  - On Perlmutter:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "ac3df6ba",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!./scripts/run_on_perlmutter.sh ./build/CMakeFiles/atlas_build_run.sh athena.py --CA CUDAExamples/02_xAODCalibConfig.py"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "52211d54-493d-4b1d-8aec-160a926d8420",
+   "metadata": {},
+   "source": [
+    "  - On SWAN:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "417cfe8e-4f03-4a8c-a9e1-c2f70e5a6f59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -115,13 +154,32 @@
     "Once you worked around the issue causing the previous failure, the code is\n",
     "technically not thread safe. Though it may be hard to test this during the\n",
     "tutorial. Still, try to run with many parallel CPU threads, and see if you can\n",
-    "make the code crash. (You may not be able to...)"
+    "make the code crash. (You may not be able to...)\n",
+    "  - On Perlmutter:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "a0c8ddde",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!./scripts/run_on_perlmutter.sh ./build/CMakeFiles/atlas_build_run.sh athena.py --threads=10 --CA CUDAExamples/02_xAODCalibConfig.py"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d98536cf-f2ca-4afc-a6fe-dc9b43470343",
+   "metadata": {},
+   "source": [
+    "  - On SWAN:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ba6b898b-e99a-4093-9b55-6e4c25fc81f7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -152,7 +210,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "NERSC Python",
    "language": "python",
    "name": "python3"
   },
@@ -166,7 +224,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,

--- a/scripts/.cmd_perlmutter.sh
+++ b/scripts/.cmd_perlmutter.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# Copyright (C) 2002-2025 CERN for the benefit of the ATLAS collaboration
+#
+
+# Find the directory the script sits in.
+SCRIPTDIR=$(cd $(dirname ${BASH_SOURCE[0]}) && pwd)
+
+# Set up the environment.
+env_perlmutter() {
+   source "${SCRIPTDIR}/.env_perlmutter.sh"
+}
+env_perlmutter
+
+# Run the received command.
+exec "$@" || exit 1

--- a/scripts/.env_perlmutter.sh
+++ b/scripts/.env_perlmutter.sh
@@ -1,0 +1,9 @@
+#
+# Copyright (C) 2002-2025 CERN for the benefit of the ATLAS collaboration
+#
+
+# Make CUDA available.
+export CMAKE_PREFIX_PATH="/opt/nvidia/hpc_sdk/Linux_x86_64/24.5/cuda/12.4"${CMAKE_PREFIX_PATH:+:${CMAKE_PREFIX_PATH}}
+export PATH="/opt/nvidia/hpc_sdk/Linux_x86_64/24.5/compilers/bin/:"${PATH:+:${PATH}}
+export LD_LIBRARY_PATH="/opt/nvidia/hpc_sdk/Linux_x86_64/24.5/cuda/12.4/lib64:/opt/nvidia/hpc_sdk/Linux_x86_64/24.5/compilers/lib"${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+export CUDACXX=`which nvcc`

--- a/scripts/cuda-gdb.sh
+++ b/scripts/cuda-gdb.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+#
+# Copyright (C) 2002-2025 CERN for the benefit of the ATLAS collaboration
+#
+
+# Unset PYTHONHOME, as it messes with cuda-gdb on both Perlmutter and SWAN.
+unset PYTHONHOME
+
+# Run cuda-gdb with all the arguments received by the script.
+cuda-gdb $@

--- a/scripts/run_on_perlmutter.sh
+++ b/scripts/run_on_perlmutter.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# Copyright (C) 2002-2025 CERN for the benefit of the ATLAS collaboration
+#
+
+# Find the directory the script sits in.
+SCRIPTDIR=$(cd $(dirname ${BASH_SOURCE[0]}) && pwd)
+
+# Command(s) received from the command line.
+CMD="$@"
+
+# Run the command using setupATLAS. Need to do it like this to avoid
+# passing all command line arguments directly to setupATLAS.
+run_cmd() {
+   export ATLAS_LOCAL_ROOT_BASE=/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase
+   source $ATLAS_LOCAL_ROOT_BASE/user/atlasLocalSetup.sh -c el9 \
+      --runtimeOpt="apptainer|--nv" --mount=/opt/nvidia \
+      --runpayload="asetup Athena,25.0.29 && ${SCRIPTDIR}/.cmd_perlmutter.sh ${CMD}"
+}
+run_cmd

--- a/scripts/setup_perlmutter.sh
+++ b/scripts/setup_perlmutter.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# Copyright (C) 2002-2025 CERN for the benefit of the ATLAS collaboration
+#
+
+# Find the directory the script sits in.
+SCRIPTDIR=$(cd $(dirname ${BASH_SOURCE[0]}) && pwd)
+
+# Set up an interactive environment using setupATLAS.
+start_env() {
+   export ATLAS_LOCAL_ROOT_BASE=/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase
+   source $ATLAS_LOCAL_ROOT_BASE/user/atlasLocalSetup.sh -c el9 \
+      --runtimeOpt="apptainer|--nv" --runtimeOpt="singularity|--nv" \
+      --runtimeOpt="docker|--gpus all" --runtimeOpt="podman| --gpus all" \
+      --mount=/opt/nvidia:/opt/nvidia \
+      --postsetup="asetup Athena,25.0.29 && source ${SCRIPTDIR}/.env_perlmutter.sh"
+}
+start_env


### PR DESCRIPTION
🥳  Made the notebooks work on Perlmutter. 🥳 

Did so by creating a set of helper scripts that could be used in the notebooks to execute the commands, as I first imagined them with SWAN / local running.

As a bit more info:
  - The scripts that the users should not be calling directly, I prefixed by "`.`". So that they would be hidden.
  - I just hardcoded the Perlmutter paths in the scripts, since now we use Perlmutter specific commands when we run there.

@cgleggett, this didn't require any specific kernel. Just like with SWAN, I re-setup the build/runtime environment separately for each cell in the notebooks. It may not be the absolute best, but it works relatively well with containers. 🤔

Pinging @beojan as well. 😄